### PR TITLE
epm repack: add support for brscanads2200ads2700w

### DIFF
--- a/repack.d/brscanads2200ads2700w.sh
+++ b/repack.d/brscanads2200ads2700w.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -x
+# It will run with two args: buildroot spec
+BUILDROOT="$1"
+SPEC="$2"
+
+# Remove LIBJPEG version
+subst '1i%filter_from_requires /LIBJPEG.*_6.2/d' $SPEC


### PR DESCRIPTION
Add repack rules for driver for scanner ADS-2700W (https://support.brother.com/g/b/downloadend.aspx?c=gb&lang=en&prod=ads2700w_us_eu_as&os=127&dlid=dlf103483_000&flang=4&type3=564).