### PR TITLE
epm repack: add libappindicator-gtk3 requirements for rustdesk

### DIFF
--- a/repack.d/rustdesk.sh
+++ b/repack.d/rustdesk.sh
@@ -25,4 +25,4 @@ remove_file /usr/share/rustdesk/files/pynput_service.py
 
 echo "Categories=GNOME;GTK;Network;RemoteAccess;" >> $BUILDROOT/usr/share/applications/$PRODUCT.desktop
 
-epm install glib2 libcairo libgdk-pixbuf libgtk+3 libpango libpulseaudio libuuid libX11 libXau libxcb libXdmcp libXfixes libXtst xdotool
+epm install glib2 libappindicator-gtk3 libcairo libgdk-pixbuf libgtk+3 libpango libpulseaudio libuuid libX11 libXau libxcb libXdmcp libXfixes libXtst xdotool


### PR DESCRIPTION
```
$ ldd /usr/lib/rustdesk/rustdesk | grep indicator
        libappindicator3.so.1 => /usr/lib64/libappindicator3.so.1 (0x00007ff96066b000)
        libindicator3.so.7 => /usr/lib64/libindicator3.so.7 (0x00007ff95fd72000)
```