### PR TITLE
Create freeplane.sh

### DIFF
--- a/play.d/freeplane.sh
+++ b/play.d/freeplane.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+PKGNAME=freeplane
+SUPPORTEDARCHES="x86_64 x86"
+DESCRIPTION="FreePlane from the official site"
+URL="http://freeplane.sourceforge.net"
+
+. $(dirname $0)/common.sh
+
+PKGURL="https://nav.dl.sourceforge.net/project/freeplane/freeplane%20stable/freeplane_1.11.2~upstream-1_all.deb"
+
+if [ "$(epm print info -s)" = "alt" ] ; then
+    repack="--repack"
+fi
+
+epm install $repack "$PKGURL"


### PR DESCRIPTION
Пакет freeplane в Sisyphus не поддерживается и 13 октября 2022 удалён из p10 а я им активно пользуюсь. Пусть ставится отсюда.