### PR TITLE
Added --nox11 to pack.d/far2l-portable.sh (ALT bug 45869)

### DIFF
--- a/pack.d/far2l-portable.sh
+++ b/pack.d/far2l-portable.sh
@@ -23,7 +23,7 @@ fi
 
 mkdir -p opt/$PRODUCT/
 
-sh $RUNFILE --noexec --target opt/$PRODUCT || fatal
+sh $RUNFILE --nox11 --noexec --target opt/$PRODUCT || fatal
 
 #mkdir -p $tdir/usr/bin/
 #ln -s /opt/$PRODUCT/$PRODUCTCUR $tdir/usr/bin/$PRODUCTCUR


### PR DESCRIPTION
Fix https://bugzilla.altlinux.org/45869 