### PR TITLE
Update switch-to-nvidia.sh

### DIFF
--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -1,42 +1,52 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+# ROSA: kroko-cli autoinstall
+# https://www.altlinux.org/Nvidia#Смена_открытых_драйверов_на_проприетарные[1]
+# https://www.altlinux.org/Переход_на_драйверы_Nvidia_и_fglrx#Установка_проприетарных_драйверов_nvidia_и_fglrx_:
 
 [ "$1" != "--run" ] && echo "Switch to using nVidia proprietary driver" && exit
 
 . $(dirname $0)/common.sh
 
 assure_root
-exit
 
 [ "$(epm print info -s)" = "alt" ] || fatal "Only ALTLinux is supported"
 
-if grep NVIDIA /proc/driver/nvidia/version 2>/dev/null ; then
-    echo "Already installed."
-    exit
+# проверяем работоспособность драйвера на текущий момент
+# TODO: добавить проверку на гибридную графику
+# TODO: добавить аргумент --force для принудительной переустановки
+if [ "$(inxi -G | grep "OpenGL: renderer" | grep "NVIDIA")" ] ; then
+	echo "Already installed."
+	exit
 fi
 
-# ROSA: kroko-cli autoinstall
-# https://www.altlinux.org/Nvidia#Смена_открытых_драйверов_на_проприетарные[1]
-
 epm update || exit
-epm update-kernel || exit
+epm upgrade || exit
 
-# TODO: проверить, совпадает ли ядро
-# reboot now
+# TODO: проверяем, совпадает ли ядро (вариант ниже требует доработки)
+# if [ ! $(update-kernel -l | grep -i "$(uname -r | awk -F'-' '{print $1}')") ] ; then
+ 	epm update-kernel || exit
+#	echo "Перезагрузитесь с новой версией ядра и повторно запустите команду epm play switch-to-nvidia"
+#	exit
+# fi
 
-# rewrite:
-#rpm -e $(rpm -qf `modinfo -F filename nouveau`)
 epm install --skip-installed nvidia_glx_common || exit
-# FIXME: really needed,
-# make-initrd
+nvidia-install-driver || exit
 
-# Возьмём команды оттуда, потому что пакета может не быть
-# epm assure /usr/bin/nvidia-install-driver nvidia_glx_common
+echo "blacklist nouveau" > /etc/modprobe.d/blacklist-nvidia-x11.conf
+installkernel $(uname -r)
 
-epm update || exit
-epm install --skip-installed apt-scripts-nvidia
-a= apt-get install-nvidia || exit
+if [ -e "/etc/X11/xorg.conf" ] && [ "$(grep -E 'nouveau|fbdev' "/etc/X11/xorg.conf")"  ] ; then
+	 rm "/etc/X11/xorg.conf"
+fi
 
-a= x11presetdrv
-a= ldconfig
+epm install --skip-installed nvidia-settings nvidia-vaapi-driver ocl-nvidia libcuda vulkan-tools \
+libnvidia-encode libnvidia-ngx libnvidia-opencl i586-libcuda i586-libnvidia-encode i586-libnvidia-opencl
+epm install --skip-installed libvulkan1 i586-libvulkan1
+
+# пакет который только в Сизифе (на данный момент):
+# apt-get install nvidia-wine
+
+# для работы 2-х и более видеокарт от nvidia необходимо добавить "nvidia-drm.modeset=1" в строку GRUB_CMDLINE_LINUX_DEFAULT= в файле /etc/default/grub и обновить grub
 
 echo "Done. Just you need reboot your system to use nVidia proprietary drivers."


### PR DESCRIPTION
Проверено на:
SimplyLinux (p10) + NVIDIA RTX 3060
Starterkit MATE (p10) с двумя видеокартами от NVIDIA: 2060 SUPER + GTX 1050 TI (для работы 2-х и более видеокарт от nvidia необходимо добавить "nvidia-drm.modeset=1" в строку GRUB_CMDLINE_LINUX_DEFAULT= в файле /etc/default/grub и обновить grub)