### PR TITLE
Fix breaking typo in i586-support.sh

### DIFF
--- a/prescription.d/i586-support.sh
+++ b/prescription.d/i586-support.sh
@@ -14,7 +14,7 @@ case "$vendor" in
             #[ -n "$verbose" ] && info "This system is ready to install 32bit packages"
             exit 0
         else
-            epm repo add "$(epm --quiet repo list | grep "x86_64 classic" | sed -e 's|x86_64 |x86_64-i586|')"
+            epm repo add "$(epm --quiet repo list | grep "x86_64 classic" | sed -e 's|x86_64|x86_64-i586|')"
             epm update
         fi
         exit


### PR DESCRIPTION
Typo in sed command that led to non-working repo references.
e.g.:
`rpm [alt] http://ftp.altlinux.org/pub/distributions/ALTLinux Sisyphus/x86_64-586classic`
instead of
`rpm [alt] http://ftp.altlinux.org/pub/distributions/ALTLinux Sisyphus/x86_64-i586 classic`