### PR TITLE
epm prescription switch-to-nvidia: added nvidia-modprobe (for the nvenc codec to work)

### DIFF
--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -61,7 +61,7 @@ if [ -e "/etc/X11/xorg.conf" ] && [ "$(grep -E 'nouveau|fbdev' "/etc/X11/xorg.co
 fi
 
 
-epm install --skip-installed nvidia-settings nvidia-vaapi-driver ocl-nvidia libcuda vulkan-tools libnvidia-encode libnvidia-ngx libnvidia-opencl libvulkan1
+epm install --skip-installed nvidia-settings nvidia-vaapi-driver ocl-nvidia libcuda vulkan-tools libnvidia-encode libnvidia-ngx libnvidia-opencl libvulkan1 nvidia-modprobe
 
 epm play i586-fix
 


### PR DESCRIPTION
Не работает кодек nvenc, при попытке его задействовать в OBS. Решается установкой nvidia-modprobe.