### PR TITLE
Update nvidia prescription

### DIFF
--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -77,9 +77,6 @@ epm play i586-fix
 # Делаем копию
 cp /etc/sysconfig/grub2 /etc/sysconfig/grub2.epmbak
 
-# для работы 2-х и более видеокарт, а так же Wayland c nvidia необходимо добавить "nvidia-drm.modeset=1" в строку GRUB_CMDLINE_LINUX_DEFAULT= в файле /etc/default/grub и обновить grub
-sed -i "s|^\(GRUB_CMDLINE_LINUX_DEFAULT='.*\)'\$|\1 nvidia-drm.modeset=1'|" /etc/sysconfig/grub2
-
 # Убирает «Неизвестный монитор» в настройках дисплеев в сессии Wayland
 sed -i "s|^\(GRUB_CMDLINE_LINUX_DEFAULT='.*\)'\$|\1 initcall_blacklist=simpledrm_platform_driver_init'|" /etc/sysconfig/grub2
 

--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -20,7 +20,6 @@ fi
 
 epm assure lspci pciutils || exit
 # проверяем работоспособность драйвера на текущий момент
-# TODO: добавить проверку на гибридную графику
 # TODO: добавить аргумент --force для принудительной переустановки
 if a= lspci -k | grep -A 2 -i "VGA" | grep "Kernel driver in use" | grep -q "nvidia" ; then
 	echo "NVIDIA driver is already installed."

--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -81,6 +81,9 @@ cp /etc/sysconfig/grub2 /etc/sysconfig/grub2.epmbak
 # Данное решение приводит к невозможности входа в tty, к отсутствию вывода логов во время загрузки (Если не включён Plymouth)
 sed -i "s|^\(GRUB_CMDLINE_LINUX_DEFAULT='.*\)'\$|\1 initcall_blacklist=simpledrm_platform_driver_init'|" /etc/sysconfig/grub2
 
+# Активируем службы управления питания NVIDIA, без этих служб будет некоректно работать уход в сон
+systemctl enable nvidia-suspend.service nvidia-resume.service nvidia-hibernate.service
+
 # Запускаем регенерацию initrd
 make-initrd
 

--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -78,6 +78,7 @@ epm play i586-fix
 cp /etc/sysconfig/grub2 /etc/sysconfig/grub2.epmbak
 
 # Убирает «Неизвестный монитор» в настройках дисплеев в сессии Wayland
+# Данное решение приводит к невозможности входа в tty, к отсутствию вывода логов во время загрузки (Если не включён Plymouth)
 sed -i "s|^\(GRUB_CMDLINE_LINUX_DEFAULT='.*\)'\$|\1 initcall_blacklist=simpledrm_platform_driver_init'|" /etc/sysconfig/grub2
 
 # Запускаем регенерацию initrd


### PR DESCRIPTION
Как и просили разделил на два отдельных pr, удаление initcall_blacklist=simpledrm_platform_driver_init нечего не сломает потому что на новых картах сейчас 535 драйвера, а старые карты просто не пустят Wayland, потому что тот же KDE требует минимум 490 драйвера, а старые карты поддерживают максимум 470