### PR TITLE
epm play: fix nekoray

### DIFF
--- a/play.d/nekoray.sh
+++ b/play.d/nekoray.sh
@@ -10,7 +10,7 @@ URL="https://github.com/MatsuriDayo/nekoray"
 arch=x64
 pkgtype=deb
 
-PKGURL=$(eget --list --latest https://github.com/MatsuriDayo/nekoray/releases "nekoray-$VERSION-debian-$arch.$pkgtype")
+PKGURL=$(eget --list --latest https://github.com/MatsuriDayo/nekoray/releases "nekoray-$VERSION-*-debian-$arch.$pkgtype")
 
 install_pkgurl
 


### PR DESCRIPTION
в названии файла также присутствует дата релиза (она мешает скачивать т.к версия берется с https://eepm.ru/releases/3.62.9/app-versions/nekoray и там она без даты), но ей можно принебречь и заменить на *, тогда всё будет работать
