### PR TITLE
epm play: workaround for discord

### DIFF
--- a/repack.d/discord.sh
+++ b/repack.d/discord.sh
@@ -17,8 +17,25 @@ fix_chrome_sandbox
 add_electron_deps
 
 rm usr/bin/$PRODUCT
-add_bin_link_command $PRODUCTCUR $PRODUCTDIR/$PRODUCTCUR
-add_bin_link_command $PRODUCT $PRODUCTCUR
+
+#disable update checking at discord start
+add_bin_exec_command $PRODUCT $PRODUCTDIR/$PRODUCTCUR
+add_bin_link_command $PRODUCTCUR $PRODUCT
+
+cat >$BUILDROOT/usr/bin/$PRODUCT <<EOF
+#!/bin/sh
+CONFIG_DIR="\$HOME"/.config/discord
+SETTINGS_FILE="\$CONFIG_DIR"/settings.json
+
+if [ -f "\$SETTINGS_FILE" ] && grep -q '"SKIP_HOST_UPDATE": true' "\$SETTINGS_FILE"; then
+	exec $PRODUCTDIR/$PRODUCTCUR "\$@"
+else
+	mkdir -p "\$CONFIG_DIR"
+	echo '{ "SKIP_HOST_UPDATE": true }' > "\$SETTINGS_FILE"
+
+	exec $PRODUCTDIR/$PRODUCTCUR "\$@"
+fi
+EOF
 
 rm usr/share/applications/discord.desktop
 install_file $PRODUCTDIR/discord.desktop /usr/share/applications/discord.desktop


### PR DESCRIPTION
Отключение проверки обновлений discord в связи с тем что epm не всегда предоставляет последние версии программ
источник:
https://wiki.archlinux.org/title/Discord#Discord_asks_for_an_update_not_yet_available_in_the_repository