### PR TITLE
fix memory allocations in switch-to-nvidia.sh

### DIFF
--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -83,6 +83,7 @@ fi
 
 # Активируем службы управления питания NVIDIA, без этих служб будет некоректно работать уход в сон
 systemctl enable nvidia-suspend.service nvidia-resume.service nvidia-hibernate.service
+echo "options nvidia NVreg_PreserveVideoMemoryAllocations=1" > /etc/modprobe.d/nvidia_memory_allocation.conf
 
 # Запускаем регенерацию initrd
 make-initrd

--- a/prescription.d/switch-to-nvidia.sh
+++ b/prescription.d/switch-to-nvidia.sh
@@ -83,7 +83,7 @@ fi
 
 # Активируем службы управления питания NVIDIA, без этих служб будет некоректно работать уход в сон
 systemctl enable nvidia-suspend.service nvidia-resume.service nvidia-hibernate.service
-echo "options nvidia NVreg_PreserveVideoMemoryAllocations=1" > /etc/modprobe.d/nvidia_memory_allocation.conf
+echo "options nvidia NVreg_PreserveVideoMemoryAllocations=1 NVreg_TemporaryFilePath=/var/tmp" > /etc/modprobe.d/nvidia_memory_allocation.conf
 
 # Запускаем регенерацию initrd
 make-initrd


### PR DESCRIPTION
Need NVreg_PreserveVideoMemoryAllocations=1 option, without it memory allocation will not work. https://download.nvidia.com/XFree86/Linux-x86_64/545.29.06/README/powermanagement.html#PreserveAllVide719f0

https://wiki.archlinux.org/title/NVIDIA/Tips_and_tricks#Preserve_video_memory_after_suspend