### PR TITLE
epm play: add sunshine

### DIFF
--- a/play.d/sunshine.sh
+++ b/play.d/sunshine.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+PKGNAME=sunshine
+SUPPORTEDARCHES="x86_64"
+VERSION="$2"
+DESCRIPTION="Self-hosted game stream host for Moonlight"
+URL="https://app.lizardbyte.dev/Sunshine"
+
+. $(dirname $0)/common.sh
+
+if [ "$VERSION" = "*" ] ; then
+	VERSION="$(curl -s https://api.github.com/repos/LizardByte/Sunshine/releases/latest | grep -oP '"tag_name": "\K(.*?)(?=")' | sed 's/G//g')"
+fi
+
+PKGURL=https://github.com/LizardByte/Sunshine/releases/download/$VERSION/sunshine.AppImage
+
+install_pkgurl


### PR DESCRIPTION
Sunshine is a self-hosted game stream host for Moonlight. Offering low latency, cloud gaming server capabilities with support for AMD, Intel, and Nvidia GPUs for hardware encoding.

- https://app.lizardbyte.dev/Sunshine
- https://t.me/altmobile_channel/58