### PR TITLE
epm play: nekoray: fix version troubles

### DIFF
--- a/play.d/nekoray.sh
+++ b/play.d/nekoray.sh
@@ -10,6 +10,11 @@ URL="https://github.com/MatsuriDayo/nekoray"
 arch=x64
 pkgtype=deb
 
+
+if [ "$VERSION" = "*" ] ; then
+	VERSION="$(eget -O- https://api.github.com/repos/MatsuriDayo/nekoray/releases/latest | grep -oP '"tag_name": "\K(.*?)(?=")' | sed 's/v//g')"
+fi
+
 PKGURL=$(eget --list --latest https://github.com/MatsuriDayo/nekoray/releases "nekoray-$VERSION-*-debian-$arch.$pkgtype")
 
 install_pkgurl

--- a/repack.d/nekoray.sh
+++ b/repack.d/nekoray.sh
@@ -3,8 +3,12 @@
 # It will be run with two args: buildroot spec
 BUILDROOT="$1"
 SPEC="$2"
-
-PRODUCT=nekoray
+if [ -f $BUILDROOT/opt/nekoray/nekoray ]
+then
+	PRODUCT=nekoray
+else
+	PRODUCT=nekobox
+fi
 PRODUCTDIR=/opt/nekoray
 
 . $(dirname $0)/common.sh
@@ -18,7 +22,7 @@ cat <<EOF |create_file /usr/share/applications/$PRODUCT.desktop
 Name=Nekoray
 Comment=Qt based cross-platform GUI proxy configuration manager (backend: Xray / sing-box)
 Exec=$PRODUCT -- %u -appdata
-Icon=/opt/nekoray/nekoray.png
+Icon=/opt/$PRODUCT/$PRODUCT.png
 Type=Application
 Terminal=false
 Categories=Network;


### PR DESCRIPTION
Изменения в play: исправлено скачивание beta версии, вместо стабильной.

@vitlav я так понимаю что бета версия [отсюда](https://download.etersoft.ru/pub/download/eepm/releases/3.62.13/app-versions/nekoray) должна пропасть (если я правильно понимаю как работает этот "бэкэнд" epm'а)

Изменения в repack: добавлена поддержка версии 4.0, где в некоторых местах nekoray поменялся на nekobox (спасибо им за головную боль)