### PR TITLE
epm [remove, install]: new flag: manual_requires

### DIFF
--- a/bin/epm
+++ b/bin/epm
@@ -147,6 +147,7 @@ force_yes=
 skip_installed=
 skip_missed=
 show_command_only=
+manual_requires=
 epm_cmd=
 warmup=
 pkg_files=
@@ -597,6 +598,9 @@ check_option()
     --force-overwrite)      # HELPOPT: force overwrite one package's file with another's file
         force_overwrite="--force-overwrite"
         ;;
+    --manual-requires)       # HELPOPT: includes all package dependencies in the install/uninstall list
+        manual_requires="--manual-requires"
+        ;;
     -*)
         [ -n "$direct_args" ] && return 1
         [ -n "$pkg_options" ] && pkg_options="$pkg_options $1" || pkg_options="$1"
@@ -665,7 +669,7 @@ if [ -n "$quiet" ] ; then
 fi
 
 # fill
-export EPM_OPTIONS="$nodeps $force $verbose $debug $quiet $interactive $non_interactive $save_only $download_only $force_overwrite"
+export EPM_OPTIONS="$nodeps $force $verbose $debug $quiet $interactive $non_interactive $save_only $download_only $force_overwrite $manual_requires"
 
 # if input is not console and run script from file, get pkgs from stdin too
 if [ ! -n "$inscript" ] && [ -p /dev/stdin ] && [ "$EPMMODE" != "pipe" ] ; then

--- a/bin/epm-install
+++ b/bin/epm-install
@@ -22,6 +22,7 @@ load_helper epm-sh-install
 load_helper epm-query
 load_helper epm-assure
 load_helper epm-repack
+load_helper epm-requires
 load_helper epm-check_updated_repo
 load_helper epm-sh-warmup
 
@@ -451,6 +452,10 @@ epm_install()
             epm_install_alt_tasks "$pkg_names"
             return
         fi
+    fi
+
+    if [ -n "$manual_requires" ] ; then
+        local pkg_names="$pkg_names $(short=1 epm_requires $pkg_names)"
     fi
 
     if [ -n "$show_command_only" ] ; then

--- a/bin/epm-remove
+++ b/bin/epm-remove
@@ -20,6 +20,7 @@
 load_helper epm-sh-altlinux
 load_helper epm-query
 load_helper epm-print
+load_helper epm-requires
 load_helper epm-sh-warmup
 load_helper epm-sh-install
 
@@ -306,6 +307,10 @@ epm_remove()
             assure_exists apt-repo
             pkg_names="$(get_task_packages $pkg_names)"
         fi
+    fi
+
+    if [ -n "$manual_requires" ] ; then
+        local pkg_names="$pkg_names $(short=1 epm_requires $pkg_names)"
     fi
 
     # TODO: fix pkg_names override


### PR DESCRIPTION
This flag will be useful for epm desktop in the future
[https://github.com/Etersoft/eepm/blob/devel/bin/epm-desktop](url)
It puts package dependencies together with the main one for autoremove to work correctly when deleting metapackages (some users really like to clean the system of what they don't need...)