### PR TITLE
epm play netbird: remove wildcard in case (eterbug #17865)

### DIFF
--- a/play.d/netbird.sh
+++ b/play.d/netbird.sh
@@ -16,9 +16,6 @@ i386)
 armv6l | armv7l)
     arch="armv6"
     ;;
-*)
-    fatal "Unsupported architecture: $arch"
-    ;;
 esac
 
 if [ "$VERSION" = "*" ]; then


### PR DESCRIPTION
The wildcard breaks the installation on x86_64(amd64) arch