### PR TITLE
epm play rudesktop: fix package name logic and URL handling

### DIFF
--- a/play.d/rudesktop.sh
+++ b/play.d/rudesktop.sh
@@ -6,25 +6,28 @@ VERSION="$2"
 DESCRIPTION="RuDesktop for Linux from the official site"
 URL="https://rudesktop.ru/"
 
-pkgname="$PKGNAME"
+. $(dirname $0)/common.sh
 
-# FIXME: uses global epm
-# change package name (like on the site)
+#case "$(epm print info -s)" in
+#  astra)
+#      PKGNAME=rudesktop-astra
+#      ;;
+#  alt)
+#      PKGNAME=rudesktop-alt
+#      ;;
+#  osnova)
+#      PKGNAME=rudesktop-osnova
+#      ;;
+#esac
+
 case "$(epm print info -s)" in
-  astra)
-      PKGNAME=rudesktop-astra
-      ;;
   alt)
       PKGNAME=rudesktop-alt
       ;;
-  osnova)
-      PKGNAME=rudesktop-osnova
+  *)
+      PKGNAME=rudesktop
       ;;
 esac
-
-. $(dirname $0)/common.sh
-
-warn_version_is_not_supported
 
 case "$(epm print info -p)" in
   rpm)
@@ -35,7 +38,12 @@ case "$(epm print info -p)" in
       ;;
 esac
 
-PKGURL="https://rudesktop.ru/download/$PKGNAME-amd64.$pkgtype"
+if [ "$VERSION" != "*" ] ; then
+    PKGURL="https://storage.rudesktop.ru/download/$PKGNAME-$VERSION-amd64.$pkgtype"
+else
+    PKGURL="$(eget --list --latest https://rudesktop.ru/downloads/ "$PKGNAME-*-amd64.$pkgtype")"
+fi
+
 install_pkgurl
 
 echo
@@ -44,5 +52,4 @@ echo "Note: run
 to enable and start $PKGNAME system service
 Use
 /usr/bin/rudesktop --rendezvous DOMAIN
-to set the domain if needed.
-"
+to set the domain if needed."


### PR DESCRIPTION
Commented out old package name logic, simplified to use rudesktop-alt only for Alt Linux, kept rudesktop for others. Updated PKGURL to match provided download links.