### PR TITLE
epm play: improve occt

### DIFF
--- a/play.d/occt.sh
+++ b/play.d/occt.sh
@@ -2,14 +2,14 @@
 
 PKGNAME=OCCT
 SUPPORTEDARCHES="x86_64"
-DESCRIPTION='test and certify your system, ensuring a comprehensive assessment of its stability.'
+DESCRIPTION="Free, all-in-one stability, stress test, benchmark and monitoring tool for PC"
 URL="https://www.ocbase.com/download"
 
 . $(dirname $0)/common.sh
 
 warn_version_is_not_supported
 
-VERSION=$(eget -O- https://www.ocbase.com/download | grep -oP '"versionStr":"\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n 1)
+VERSION=$(eget -q -O- https://www.ocbase.com/download | grep -oP '"versionStr":"\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n1)
 PKGURL="https://dl.ocbase.com/linux/per/stable/OCCT"
 
 install_pack_pkgurl "$VERSION"


### PR DESCRIPTION
Add -q flag to eget to prevent saving extra files and reduce output noise