### PR TITLE
epm play occt: improve (eterbug #18266)

### DIFF
--- a/pack.d/OCCT.sh
+++ b/pack.d/OCCT.sh
@@ -8,15 +8,13 @@ VERSION="$3"
 
 PKGNAME=$PRODUCT-$VERSION
 
-mkdir -p opt/OCCT
-mv -v $TAR opt/OCCT/occt
-chmod 0755 opt/OCCT/occt
-
-cat <<EOF | create_file /opt/OCCT/OCCT.config.json
-{
-  "CheckForUpdates": "Disabled",
-}
-EOF
+mkdir -p opt/occt
+mv -v $TAR opt/occt/occt
+chmod 0755 opt/occt/occt
+# Disable automatic updates in future release
+touch "opt/occt/disable_update"
+# Use configs in home dir
+touch "opt/occt/use_home_config"
 
 cat <<EOF | create_file /usr/share/applications/occt.desktop
 [Desktop Entry]

--- a/play.d/occt.sh
+++ b/play.d/occt.sh
@@ -2,14 +2,17 @@
 
 PKGNAME=OCCT
 SUPPORTEDARCHES="x86_64"
+VERSION="$2"
 DESCRIPTION="Free, all-in-one stability, stress test, benchmark and monitoring tool for PC"
 URL="https://www.ocbase.com/download"
 
 . $(dirname $0)/common.sh
 
-warn_version_is_not_supported
-
-VERSION=$(eget -q -O- https://www.ocbase.com/download | grep -oP '"versionStr":"\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n1)
-PKGURL="https://dl.ocbase.com/linux/per/stable/OCCT"
+if [ "$VERSION" = "*" ] ; then
+    VERSION=$(eget -q -O- https://www.ocbase.com/download | grep -oP '"versionStr":"\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n1)
+    PKGURL="https://dl.ocbase.com/linux/per/stable/OCCT"
+else
+    PKGURL="https://www.ocbase.com/download/edition:Personal/os:Linux/version:$VERSION"
+fi
 
 install_pack_pkgurl "$VERSION"

--- a/repack.d/OCCT.sh
+++ b/repack.d/OCCT.sh
@@ -8,5 +8,5 @@ SPEC="$2"
 
 add_libs_requires
 
-add_bin_exec_command occt "/opt/OCCT/occt"
+add_bin_exec_command occt "/opt/occt/occt"
 


### PR DESCRIPTION
Добавил возможность указать версию
Переместил файл в opt/occt вместо opt/OCCT что бы работали файлы настроек (с капсом почему-то не работает)
Добавил файл disable_update для отключения автообновлений 
Добавил файл use_home_config что бы конфиг записывался в ~/.config/occt, а не туда где бинарник