### PR TITLE
epm play wps office: Adding fonts installation for WPS Office to fix formula display warnings

### DIFF
--- a/repack.d/wpsoffice.sh
+++ b/repack.d/wpsoffice.sh
@@ -4,6 +4,7 @@
 BUILDROOT="$1"
 SPEC="$2"
 PRODUCTDIR=/opt/kingsoft/wps-office
+FONTDIR=/usr/share/fonts/wps-office
 
 . $(dirname $0)/common.sh
 
@@ -63,5 +64,18 @@ for f in wps et wpp wpspdf; do
     [ -f "$bin_file" ] || fatal "Missing $bin_file"
     sed -i '2i . /opt/kingsoft/wps-office/office6/setenv.sh' "$bin_file"
 done
+
+# Installs Symbol, Wingdings, and MT Extra fonts to fix WPS Office formula display warning
+if [ ! -d "$FONTDIR" ] || ! find "$FONTDIR" -maxdepth 1 -type f -iname '*.ttf' | grep -q .; then
+    echo "Installing WPS Office required fonts..."
+    eget -O wps-fonts.zip https://github.com/CatSema/ttf-wps-fonts/archive/refs/heads/master.zip
+    unzip -q wps-fonts.zip
+    mkdir -p "$FONTDIR"
+    find ttf-wps-fonts-master -maxdepth 1 -type f -iname '*.ttf' -exec mv {} "$FONTDIR" \;
+    chmod 0644 "$FONTDIR"/*.ttf 2>/dev/null || true
+    fc-cache -fs
+    rm -rf wps-fonts.zip ttf-wps-fonts-master
+    echo "Font installation completed."
+fi
 
 add_libs_requires

--- a/repack.d/wpsoffice.sh
+++ b/repack.d/wpsoffice.sh
@@ -49,4 +49,19 @@ subst 's/python -c '\''import sys, urllib; print urllib.unquote(sys.argv\[1\])'\
 remove_file $PRODUCTDIR/office6/mui/zh_CN/resource/help/etrainbow/images/Ribbon/custom_%20sequence.gif
 #remove_dir $PRODUCTDIR/office6/mui/zh_CN/resource/help/etrainbow/images
 
+# Fixes the problem of incorrect text display in WPS Office in non-GTK environments (KDE, Lxde, etc.)
+cat <<EOF | create_file "$PRODUCTDIR/office6/setenv.sh"
+#!/bin/bash
+
+if echo "\${XDG_CURRENT_DESKTOP:-}" | grep -qi 'kde'; then
+    export XDG_CURRENT_DESKTOP=GNOME
+fi
+EOF
+
+for f in wps et wpp wpspdf; do
+    bin_file="$BUILDROOT/usr/bin/$f"
+    [ -f "$bin_file" ] || fatal "Missing $bin_file"
+    sed -i '2i . /opt/kingsoft/wps-office/office6/setenv.sh' "$bin_file"
+done
+
 add_libs_requires


### PR DESCRIPTION
Прошу рассмотреть возможность добавить для устранения "Некоторые символы формул могут отображаться некорректно из-за отсутствия шрифтов Symbol, Wingdings, Wingdings 2, Wingdings 3, MT Extra" автоматическую установку недостающих шрифтов в процессе установки WPS Office. Данный фикс реализует проверку наличия необходимых .ttf-файлов, скачивание архива с требуемыми шрифтами из репозитория, их установку в системный каталог и обновление кэша шрифтов. Это позволяет избавиться от предупреждения о недостающих шрифтах и обеспечивает корректное отображение формул и специальных символов в документах WPS Office.
![image_2025-06-13_22-56-10](https://github.com/user-attachments/assets/427ade08-9621-444b-aa2c-5f96de8f5a2c)
