### PR TITLE
epm play lenza: added glibc version check

### DIFF
--- a/play.d/lenza.sh
+++ b/play.d/lenza.sh
@@ -8,6 +8,10 @@ URL="https://lenzaos.com/"
 
 . $(dirname $0)/common.sh
 
+if ! is_glibc_enough 2.34 ; then
+    fatal "glibc is too old"
+fi
+
 if [ "$VERSION" = "*" ] ; then
     VERSION=$(eget -O- https://lenzaos.com/ | grep -oP 'Lenza-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.AppImage)')
 fi


### PR DESCRIPTION
На P10 такая ошибка

A JavaScript error occurred in the main process
Uncaught Exception:
Error: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /tmp/.private/user/.mount_L
enza-rB8BhQ/resources/app.asar.unpacked/node_modules/uiohook-napi/build/Release/uiohook_napi.node)