### PR TITLE
`epm play`: updated RustRover download path

### DIFF
--- a/play.d/rustrover.sh
+++ b/play.d/rustrover.sh
@@ -8,6 +8,6 @@ URL="https://www.jetbrains.com/rust/"
 
 . $(dirname $0)/common-jetbrains.sh
 
-PKGURL="$(get_jetbrains_pkgurl RR rust)"
+PKGURL="$(get_jetbrains_pkgurl RR rustrover)"
 
 install_pkgurl


### PR DESCRIPTION
Fixed a bug from the Telegram EEPM chat, changed "rust" to "rustrover" in `epm play`'s `PKGURL=`.