### PR TITLE
Fixed a typo in "Unknown command" message for `epm mark`.

### DIFF
--- a/bin/epm-mark
+++ b/bin/epm-mark
@@ -363,7 +363,7 @@ epm_mark()
         epm_mark_showmanual "$@"
         ;;
     *)
-        fatal 'Unknown command $ epm repo $CMD'
+        fatal 'Unknown command $ epm mark $CMD'
         ;;
 esac
 


### PR DESCRIPTION
A smallest fix.
```
ERROR: Unknown command $ epm repo XYZ
                             ↓↓↓↓
ERROR: Unknown command $ epm mark XYZ
```