### PR TITLE
epm play popcorn time: added openssl3 check

### DIFF
--- a/play.d/popcorn-time.sh
+++ b/play.d/popcorn-time.sh
@@ -8,6 +8,8 @@ URL="https://github.com/popcorn-official/popcorn-desktop"
 
 . $(dirname $0)/common.sh
 
+is_soname_present libssl.so.3 || fatal "This package needs OpenSSL 3."
+
 warn_version_is_not_supported
 
 PKGURL=$(eget --list https://popcorntime.app/download "*.deb")

--- a/repack.d/popcorn-time-nightly.sh
+++ b/repack.d/popcorn-time-nightly.sh
@@ -14,5 +14,4 @@ fix_desktop_file "Categories=" "Categories=Network;Video;"
 # workaround for Nvidia
 fix_desktop_file "Exec=popcorntime-tauri" "Exec=WEBKIT_DISABLE_DMABUF_RENDERER=1 GDK_BACKEND=x11 popcorntime-tauri"
 
-
 add_libs_requires


### PR DESCRIPTION
The following packages have unmet dependencies:
  popcorn-time-nightly: Depends: libcrypto.so.3()(64bit) but it is not installable
                        Depends: libjavascriptcoregtk-4.1.so.0()(64bit) but it is not installable
                        Depends: libsoup-3.0.so.0()(64bit) but it is not installable
                        Depends: libssl.so.3()(64bit) but it is not installable
                        Depends: libwebkit2gtk-4.1.so.0()(64bit) but it is not installable