### PR TITLE
Fix `epm download` command exit code if no package can be fetched.

### DIFF
--- a/bin/epm-download
+++ b/bin/epm-download
@@ -277,9 +277,12 @@ startwith_inlist()
     return 1
 }
 
+    # Non-local variable because `local` builtin returns exit code "0" even if command substitution fails.
+    epm_download_alt__result_url="$(__epm_alt_get_package_url install --reinstall "$@")" || return
+
     # old systems ignore reinstall ?
     local url
-    for url in $(__epm_alt_get_package_url install --reinstall "$@") ; do
+    for url in $epm_download_alt__result_url ; do
         startwith_inlist "$(basename "$url")" "$@" || continue
         [ -n "$print_url" ] && echo "$url" && continue
         # TODO: download together


### PR DESCRIPTION
Если пакет скачать невозможно, то `epm download` не сообщает об этом ненулевым кодом ошибки.

Проблема здесь в том, что command substitution внутри builtin-команд вроде `for` или `local` возвращают код ошибки внутрь тех самых `for` и `local`, а те его тихо съедают. Таким образом на выходе `local A=$(false)` окажется "0", а не "1". То же самое происходит в файле "epm-download", в функции `__epm_download_alt()`.

Пример в терминале (`export` в данном случае работает по таким же правилам):
```bash
$ export A="$(false)"; echo $?
0

$ A="$(false)"; echo $?
1
```