### PR TITLE
epm play karing: fix correct version format handling for package

### DIFF
--- a/pack.d/karing.sh
+++ b/pack.d/karing.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+TAR="$1"
+RETURNTARNAME="$2"
+VERSION="$3"
+PRODUCT=karing
+
+. $(dirname $0)/common.sh
+
+# Form package name with correct version
+PKGNAME="$PRODUCT-$VERSION.$(basename $TAR | sed 's/.*\.//')"
+
+# Copy source package with new name preserving original extension
+cp $TAR $PKGNAME || fatal
+
+return_tar $PKGNAME

--- a/play.d/antigravity.sh
+++ b/play.d/antigravity.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+PKGNAME=antigravity
+SUPPORTEDARCHES="x86_64 aarch64"
+VERSION="$2"
+DESCRIPTION="An agentic development platform from Google, evolving the IDE into the agent-first era"
+URL="https://antigravity.google"
+
+. $(dirname $0)/common.sh
+
+warn_version_is_not_supported
+
+arch="$(epm print info --debian-arch)"
+PKG_INDEX_URL="https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/dists/antigravity-debian/main/binary-${arch}/Packages"
+
+PKGVER="$(eget -O- "$PKG_INDEX_URL" \
+    | grep '^Version:' \
+    | tail -n1 \
+    | cut -d' ' -f2)"
+
+PKGMD5="$(eget -O- "$PKG_INDEX_URL" \
+    | grep '^MD5sum:' \
+    | tail -n1 \
+    | cut -d' ' -f2)"
+
+PKGURL="https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_${PKGVER}_${arch}_${PKGMD5}.deb"
+
+install_pkgurl

--- a/play.d/karing.sh
+++ b/play.d/karing.sh
@@ -18,12 +18,11 @@ rpm)
 esac
 
 if [ "$VERSION" = "*" ]; then
-	PKGURL=$(get_github_url "https://github.com/KaringX/karing/" "karing_*_linux_amd64.$pkgtype")
-else
-	PKGURL="https://github.com/KaringX/karing/releases/download/v${VERSION}/karing_${VERSION}_linux_amd64.$pkgtype"
+	VERSION="$(get_github_tag "https://github.com/KaringX/karing/")"
 fi
+PKGURL="https://github.com/KaringX/karing/releases/download/v${VERSION}/karing_${VERSION}_linux_amd64.$pkgtype"
 
-install_pkgurl
+install_pack_pkgurl $VERSION
 
 cat <<EOF
 

--- a/repack.d/antigravity.sh
+++ b/repack.d/antigravity.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -x
+
+# It will be run with two args: buildroot spec
+BUILDROOT="$1"
+SPEC="$2"
+
+. $(dirname $0)/common.sh
+
+move_to_opt
+
+add_electron_deps
+
+fix_desktop_file /usr/share/antigravity/antigravity
+
+add_bin_link_command $PRODUCT /opt/$PRODUCT/bin/antigravity


### PR DESCRIPTION
Addresses incorrect version parsing that resulted in karing-1.2.13+1600 instead of expected karing-1.2.13.1600 format