### PR TITLE
epm play: added WPS Office dictionaries

### DIFF
--- a/pack.d/wps-office-dicts.sh
+++ b/pack.d/wps-office-dicts.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+TAR="$1"
+RETURNTARNAME="$2"
+VERSION="$3"
+URL="$4"
+
+. $(dirname $0)/common.sh
+
+PKGNAME=$PRODUCT-$VERSION
+
+erc unpack "$TAR" || fatal
+
+SRCDIR="$(basename "$TAR" .zip)"
+SPELLCHECK_DIR="$SRCDIR/spellcheck"
+
+DEST="opt/kingsoft/wps-office/office6/dicts/spellcheck"
+mkdir -p "$DEST" || fatal
+cp -a "$SPELLCHECK_DIR"/. "$DEST"/ || fatal
+
+erc pack $PKGNAME.tar opt || fatal
+
+return_tar $PKGNAME.tar

--- a/play.d/antigravity.sh
+++ b/play.d/antigravity.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+PKGNAME=antigravity
+SUPPORTEDARCHES="x86_64 aarch64"
+VERSION="$2"
+DESCRIPTION="An agentic development platform from Google, evolving the IDE into the agent-first era"
+URL="https://antigravity.google"
+
+. $(dirname $0)/common.sh
+
+warn_version_is_not_supported
+
+arch="$(epm print info --debian-arch)"
+PKG_INDEX_URL="https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/dists/antigravity-debian/main/binary-${arch}/Packages"
+
+PKGVER="$(eget -O- "$PKG_INDEX_URL" \
+    | grep '^Version:' \
+    | tail -n1 \
+    | cut -d' ' -f2)"
+
+PKGMD5="$(eget -O- "$PKG_INDEX_URL" \
+    | grep '^MD5sum:' \
+    | tail -n1 \
+    | cut -d' ' -f2)"
+
+PKGURL="https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/pool/antigravity-debian/antigravity_${PKGVER}_${arch}_${PKGMD5}.deb"
+
+install_pkgurl

--- a/play.d/wps-office-dicts.sh
+++ b/play.d/wps-office-dicts.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+PKGNAME=wps-office-dicts
+SUPPORTEDARCHES="x86_64"
+DESCRIPTION="Spellcheck dictionaries for WPS Office"
+URL="https://github.com/slackalaxy/wps-office-dicts"
+VERSION="$2"
+
+. $(dirname $0)/common.sh
+
+if [ "$VERSION" = "*" ]; then
+	VERSION="$(get_github_tag "https://github.com/slackalaxy/wps-office-dicts/")"
+fi
+PKGURL="https://github.com/slackalaxy/wps-office-dicts/archive/refs/tags/${VERSION}.zip"
+
+install_pack_pkgurl $VERSION

--- a/repack.d/antigravity.sh
+++ b/repack.d/antigravity.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -x
+
+# It will be run with two args: buildroot spec
+BUILDROOT="$1"
+SPEC="$2"
+
+. $(dirname $0)/common.sh
+
+move_to_opt
+
+add_electron_deps
+
+fix_desktop_file /usr/share/antigravity/antigravity
+
+add_bin_link_command $PRODUCT /opt/$PRODUCT/bin/antigravity

--- a/repack.d/wps-office-dicts.sh
+++ b/repack.d/wps-office-dicts.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -x
+
+# It will be run with two args: buildroot spec
+BUILDROOT="$1"
+SPEC="$2"
+
+. $(dirname $0)/common.sh
+
+add_requires "/usr/bin/wps"


### PR DESCRIPTION
Add play/pack scripts to fetch the latest tag and install spellcheck dictionaries into `/opt/kingsoft/wps-office/office6/dicts/spellcheck`.