### PR TITLE
Fix `epm download` exit code when the package cannot be fetched (again).

### DIFF
--- a/bin/epm-download
+++ b/bin/epm-download
@@ -284,6 +284,7 @@ startwith_inlist()
     local urls=""
     [ -n "$pkg_noninstalled" ] && urls="$(__epm_alt_get_package_url install $pkg_noninstalled)"
     [ -n "$pkg_installed" ] && urls="$urls $(__epm_alt_get_package_url install --reinstall $pkg_installed)"
+    [ -z "$urls" ] && return 1
     local url
     for url in $urls ; do
         startwith_inlist "$(basename "$url")" "$@" || continue


### PR DESCRIPTION
В коммите 7a7a14f806f47a7372edc1fffc9b99c3d1ccf48f поведение `epm download` снова сломалось.