### PR TITLE
Passing a $quiet flag from `epm ql` to `ercat` tool.

### DIFF
--- a/bin/epm-filelist
+++ b/bin/epm-filelist
@@ -42,7 +42,7 @@ __alt_local_content_filelist()
 
     {
         [ -n "$USETTY" ] && info 'Search in $CI for $pkg...'
-        ercat $CI | grep -h -P -- ".*\t$pkg$" | sed -e "s|\(.*\)\t\(.*\)|\1|g"
+        ercat $quiet $CI | grep -h -P -- ".*\t$pkg$" | sed -e "s|\(.*\)\t\(.*\)|\1|g"
     } | $OUTCMD
 }
 


### PR DESCRIPTION
Отключение вывода команд для вызываемой утилиты `ercat` (`./tools_ercat`). Такое же поведение, например, в `epm sf`.