### PR TITLE
epm play: heroic-games-launcher switch to deb/rpm packages

### DIFF
--- a/play.d/heroic-games-launcher.sh
+++ b/play.d/heroic-games-launcher.sh
@@ -8,11 +8,23 @@ URL="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher"
 
 . $(dirname $0)/common.sh
 
-arch=x86_64
+pkgtype="$(epm print info -p)"
+
+case $pkgtype in
+    rpm)
+        pkgformat="rpm"
+        arch=$(epm print info -a)
+        ;;
+    *)
+        pkgformat="deb"
+        arch=$(epm print info --debian-arch)
+        ;;
+esac
+
 if [ "$VERSION" = "*" ] ; then
-    PKGURL=$(get_github_url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/" "${PKGNAME}-${VERSION}-linux-$arch.AppImage")
+    PKGURL=$(get_github_url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/" "${PKGNAME}-${VERSION}-linux-$arch.$pkgformat")
 else
-    PKGURL="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v$VERSION/${PKGNAME}-${VERSION}-linux-$arch.AppImage"
+    PKGURL="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v$VERSION/${PKGNAME}-${VERSION}-linux-$arch.$pkgformat"
 fi
 
 install_pkgurl


### PR DESCRIPTION
Switch from AppImage to .deb/.rpm because AppImage repack gets a `~linux` suffix and leads to versions like `Heroic-2.20.0~linux-linux-x86_64`.

Closes #576

Remaining: fix version on the server side at https://eepm.ru/releases/3.64/app-versions/.