### PR TITLE
epm play anilibrix:  fix PKGNAME (eterbug #17865)

### DIFF
--- a/play.d/anilibrix.sh
+++ b/play.d/anilibrix.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PKGNAME=AniLibrix-linux
+PKGNAME=AniLibrix
 SUPPORTEDARCHES="x86_64"
 VERSION="$2"
 DESCRIPTION="Anilibria desktop anime cinema for any of your computers"


### PR DESCRIPTION
epm play anilibrix: fix PKGNAME after generic-appimage strips -linux suffix