### PR TITLE
is_openssl_enough: check libssl3.so instead of package openssl

### DIFF
--- a/play.d/common.sh
+++ b/play.d/common.sh
@@ -432,9 +432,8 @@ is_glibc_enough()
 is_openssl_enough()
 {
     local needed="$1"
-    local PKG="openssl"
 
-    is_pkg_enough $PKG $needed
+    is_soname_present "libssl.so.$needed"
 }
 
 get_path_by_soname()


### PR DESCRIPTION
В тестировании, в контейнерах, утилиты openssl нету, она никем не тянется. В отличии от libssl3, которую тянет wget.  У пользователей утилита openssl есть, её тянет тотже NetworkManager:
$ epm wd openssl | grep -i network
 $ apt-cache whatdepends openssl
  glib-networking-tests-2.80.1-altsisyphus+389466.2600.79.1@1759571969
  NetworkManager-daemon-1.56.0-altsisyphus+408117.100.1.1@1770977650

поэтому жалоб на 10 пакетов, использующих эту проверку, у пользователей может не быть.  Однако, в CI это мешает видеть реальные проблемы этих пакетов - их отбрасывает с ошибкой: 
There is no needed OpenSSL 3
При том, что библиотека нужной версии имеется, поэтому предлагаю проверять наличие либы.  