### PR TITLE
epm pack codex: fix mv glob matching both binary and .tar.gz (eterbug…

### DIFF
--- a/pack.d/codex.sh
+++ b/pack.d/codex.sh
@@ -12,7 +12,7 @@ URL="$4"
 
 mkdir -p usr/bin
 erc --here unpack "$TAR" || fatal
-mv codex-* usr/bin/codex || fatal
+mv "$(basename "$TAR" .tar.gz)" usr/bin/codex || fatal
 chmod 755 usr/bin/codex
 
 PKGNAME=$PRODUCT-$VERSION


### PR DESCRIPTION
… #17865)