### PR TITLE
pack pantum: detect extracted driver dir before rename

### DIFF
--- a/pack.d/pantum.sh
+++ b/pack.d/pantum.sh
@@ -27,8 +27,20 @@ else
     fatal "We support only Pantum Ubuntu Driver V.*.zip"
 fi
 
-# drop dirname with spaces
-mv Pantum* PantumDriver || fatal
+# normalize upstream directory name (archive may also contain the source .zip)
+DRIVERDIR=
+for d in * ; do
+    [ -d "$d/Resources" ] || continue
+    DRIVERDIR="$d"
+    break
+done
+
+[ -n "$DRIVERDIR" ] || fatal "Can't find unpacked Pantum driver directory"
+
+if [ "$DRIVERDIR" != "PantumDriver" ] ; then
+    mv "$DRIVERDIR" PantumDriver || fatal
+fi
+
 cd PantumDriver/Resources || fatal
 
 case "$(epm print info -a)" in


### PR DESCRIPTION
Исправление:
```
Extracting archive: /var/tmp/tmp.2M5LuLbunk/Pantum-Ubuntu-Driver-V1_1_123.zip
--
Path = /var/tmp/tmp.2M5LuLbunk/Pantum-Ubuntu-Driver-V1_1_123.zip
Type = zip
Physical Size = 10188191

Everything is Ok

Folders: 32
Files: 96
Size:       10861348
Compressed: 10188191
mv: цель 'PantumDriver': Нет такого файла или каталога
FATAL: 
ERROR:   (you can discuss this problem (epm 3.64.59-alt1 on ALTLinux/Sisyphus) in Telegram: https://t.me/useepm, MAX: https://max.eepm.ru, Matrix: https://matrix.eepm.ru)

Tip: try $ epm play --ipfs pantum to install from IPFS cache.
ERROR: There was some error during install the application.  (you can discuss this problem (epm 3.64.59-alt1 on ALTLinux/Sisyphus) in Telegram: https://t.me/useepm, MAX: https://max.eepm.ru, Matrix: https://matrix.eepm.ru)
```