### PR TITLE
github ci: don't check core on debian yet (eterbug #18828)

### DIFF
--- a/.github/ci/components.map
+++ b/.github/ci/components.map
@@ -1,6 +1,6 @@
 # component | changed paths (comma-separated)             | systems (comma-separated)
 play         | play.d/, pack.d/, repack.d/                | debian:bookworm, alt:p11, fedora:43
-core         | bin/, etc/                                  | debian:bookworm, alt:p11
+core         | bin/, etc/                                  | alt:p11
 tests        | tests/                                      | alt:p11
 tests-smoke  | bin/, tests/                                | alt:p11
-ci           | .github/ci/, .github/workflows/pr-test.yml  | debian:bookworm
+ci           | .github/ci/, .github/workflows/pr-test.yml  | ubuntu:24.04

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
           esac
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
update node version
selfcheck ci on default github container