### PR TITLE
epm prescription i586-fix: added freetype

### DIFF
--- a/prescription.d/i586-fix.sh
+++ b/prescription.d/i586-fix.sh
@@ -22,6 +22,7 @@ for i in glibc-nss glibc-gconv-modules \
          libgamemodeauto0 \
          vkBasalt \
          mangohud \
+         libfreetype \
          $(epmqp --short libnss | grep "^libnss-" | grep -v "libnss-fallback") \
          $(epmqp --short xorg-dri | grep "^xorg-dri-")
 do


### PR DESCRIPTION
fix for 

Wine cannot find the FreeType font library.  To enable Wine to
use TrueType fonts please install a version of FreeType greater than
or equal to 2.0.5.
http://www.freetype.org