### PR TITLE
epm play: add Figma Linux Next as a separate package

### DIFF
--- a/play.d/figma.sh
+++ b/play.d/figma.sh
@@ -1,21 +1,42 @@
 #!/bin/sh
 
-PKGNAME=figma-linux
+PKGNAME=figma-linux-next
 SUPPORTEDARCHES="x86_64 aarch64"
 VERSION="$2"
-DESCRIPTION="Figma-linux - an unofficial Electron-based Figma desktop app for Linux"
-URL="https://github.com/Figma-Linux/figma-linux"
+DESCRIPTION="Figma Linux Next - an unofficial Electron-based Figma desktop app for Linux"
+URL="https://github.com/arximus88/figma-linux-next"
 
 . $(dirname $0)/common.sh
 
 [ "$VERSION" = "*" ] && VERSION="[0-9]*"
 
 pkgtype="$(epm print info -p)"
-arch="$(epm print info --distro-arch)"
 
-file="${PKGNAME}_${VERSION}_linux_$arch.$pkgtype"
+# Figma Linux Next uses Debian architecture names for .deb and distro
+# architecture names for .rpm. Its Pacman build is currently x86_64 only.
+case "$pkgtype" in
+    deb)
+        arch="$(epm print info --debian-arch)"
+        ;;
+    rpm)
+        arch="$(epm print info --distro-arch)"
+        ;;
+    pacman)
+        case "$(epm print info -a)" in
+            x86_64)
+                arch=x64
+                ;;
+            *)
+                fatal "Figma Linux Next does not publish a Pacman package for this architecture"
+                ;;
+        esac
+        ;;
+    *)
+        fatal "$pkgtype package format is not supported"
+        ;;
+esac
 
-PKGURL=$(eget --list --latest https://github.com/Figma-Linux/figma-linux/releases "$file")
+file="${PKGNAME}_${VERSION}_linux_${arch}.${pkgtype}"
+PKGURL=$(get_github_url "$URL" "$file")
 
 install_pkgurl
-

--- a/repack.d/figma-linux-next.sh
+++ b/repack.d/figma-linux-next.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -x
+
+# It will be run with two args: buildroot spec
+BUILDROOT="$1"
+SPEC="$2"
+
+. $(dirname $0)/common-chromium-browser.sh
+
+add_bin_link_command
+
+fix_desktop_file
+
+add_electron_deps


### PR DESCRIPTION
Switch epm play figma from the unmaintained Figma-Linux project to Figma Linux Next. Handle the release architecture names for RPM, DEB, and Pacman packages, and add a matching repack rule for figma-linux-next. Tested with the latest v0.15.0 RPM on ALT Linux: URL resolution, repacking, installation, launcher, and desktop entry work.