### PR TITLE
epm play: add Sharp UD PCL6 package scripts

### DIFF
--- a/pack.d/sharp-ud-pcl6.sh
+++ b/pack.d/sharp-ud-pcl6.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+TAR="$1"
+RETURNTARNAME="$2"
+
+. $(dirname $0)/common.sh
+
+VERSION=1.18
+PKGNAME=$PRODUCT-$VERSION
+
+erc --here unpack "$TAR" || fatal
+
+INNER_TAR=$(find . -maxdepth 2 -type f -name 'Sharp-*-UD-PCL6-64bit.tar.gz' | head -n 1)
+[ -n "$INNER_TAR" ] || fatal "Can't find Sharp Universal PCL6 tarball"
+erc --here unpack "$INNER_TAR" || fatal
+
+DRIVERDIR=$(find . -type f -name 'Sharp-UD-Color-PCL6.ppd' -exec dirname {} \; | head -n 1)
+[ -n "$DRIVERDIR" ] || fatal "Can't find Sharp Universal Color PCL6 PPD"
+[ -f "$DRIVERDIR/Sharp-UD-Mono-PCL6.ppd" ] || fatal "Can't find Sharp Universal Mono PCL6 PPD"
+[ -x "$DRIVERDIR/filter/sv2epjl" ] || fatal "Can't find executable Sharp sv2epjl filter"
+[ -f "$DRIVERDIR/mime/sv2ecnv.convs" ] || fatal "Can't find Sharp MIME conversion rules"
+[ -f "$DRIVERDIR/mime/sv2etyp.types" ] || fatal "Can't find Sharp MIME type rules"
+
+COLOR_PPD="$DRIVERDIR/Sharp-UD-Color-PCL6.ppd"
+MONO_PPD="$DRIVERDIR/Sharp-UD-Mono-PCL6.ppd"
+
+for PPD in "$COLOR_PPD" "$MONO_PPD" ; do
+    sed -i 's/\r$//' "$PPD" || fatal "Can't normalize $PPD line endings"
+    # Named constraints require matching resolvers, which the Sharp PPDs lack.
+    sed -i -E 's/^\*cupsUIConstraints[[:space:]]+[^:]+:/\*cupsUIConstraints:/' "$PPD" \
+        || fatal "Can't repair cupsUIConstraints in $PPD"
+    # Add the explicit PDF to PCL XL chain required by modern CUPS.
+    sed -i '/^\*cupsFilter:.*application\/vnd.cups-pxl.*sv2epjl/i\
+*cupsFilter2: "application/pdf application/vnd.cups-pxl 66 gstopxl"\
+*cupsFilter2: "application/vnd.cups-pdf application/vnd.cups-pxl 66 gstopxl"\
+*cupsFilter2: "application/postscript application/vnd.cups-pxl 100 gstopxl"\
+*cupsFilter2: "application/vnd.cups-postscript application/vnd.cups-pxl 100 gstopxl"\
+*cupsFilter2: "application/vnd.cups-pxl application/vnd.sharp-pcl6 100 sv2epjl"' "$PPD" || fatal
+done
+
+# Avoid monochrome mode when CUPS imports the color PPD.
+sed -i 's/^\*DefaultColorModel:[[:space:]]*Automatic/\*DefaultColorModel: RGB/' "$COLOR_PPD" || fatal
+
+install -Dm0555 "$DRIVERDIR/filter/sv2epjl" "usr/lib/cups/filter/sv2epjl"
+install -Dm0644 "$COLOR_PPD" "usr/share/cups/model/Sharp/Sharp-UD-Color-PCL6.ppd"
+install -Dm0644 "$MONO_PPD" "usr/share/cups/model/Sharp/Sharp-UD-Mono-PCL6.ppd"
+install -Dm0644 "$DRIVERDIR/mime/sv2ecnv.convs" "usr/share/cups/mime/sv2ecnv.convs"
+install -Dm0644 "$DRIVERDIR/mime/sv2etyp.types" "usr/share/cups/mime/sv2etyp.types"
+
+erc pack "$PKGNAME.tar" usr || fatal
+
+cat <<EOF >"$PKGNAME.tar.eepm.yaml"
+name: $PRODUCT
+version: $VERSION
+group: System/Configuration/Printing
+license: GPL-2.0-or-later and LicenseRef-Sharp
+url: https://sharpone.sharp.co.uk/
+summary: Sharp Universal PCL6 printer driver for Linux
+description: Sharp Universal Color and Mono PCL6 printer driver for Linux.
+requires: cups cups-filters ghostscript
+EOF
+
+return_tar "$PKGNAME.tar"

--- a/play.d/sharp-ud-pcl6.sh
+++ b/play.d/sharp-ud-pcl6.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+PKGNAME=sharp-ud-pcl6
+SUPPORTEDARCHES="x86_64"
+VERSION="$2"
+DESCRIPTION="Sharp Universal PCL6 printer driver for Linux"
+URL="https://sharpone.sharp.co.uk/"
+
+. $(dirname $0)/common.sh
+
+warn_version_is_not_supported
+
+# Sharp blocks direct downloads in some regions. Run: epm play --ipfs sharp-ud-pcl6
+PKGURL="https://sharpone.sharp.co.uk/api/pim/download/161e02c5-0073-4ded-a874-c13585b67b78"
+PKGSUM="sha256:8a804fe78a3950a6ca137e91dfac2de0f952589b0b6674ba903204c6a7a0f495"
+
+install_pack_pkgurl "1.18" "$PKGSUM"
+
+echo "Note: run
+# serv cups restart
+to enable new Sharp Universal Color and Mono PCL6 printer models in cups
+"


### PR DESCRIPTION
Добавлен рецепт `sharp-ud-pcl6` для установки официального универсального драйвера Sharp PCL6 1.18 под Linux.

Рецепт загружает архив с официального сервера SharpONE, проверяет его по SHA-256, устанавливает цветной и монохромный PPD, а также фирменный фильтр `sv2epjl`.

Официальный сервер `https://sharpone.sharp.co.uk/` недоступен из некоторых регионов, включая российские сети. В таком случае драйвер следует устанавливать через IPFS-кеш eepm:

```shell
epm play --ipfs sharp-ud-pcl6
```

Для обычной прямой загрузки:

```shell
epm play sharp-ud-pcl6
```

В качестве основного источника намеренно сохранён официальный URL Sharp. Подтверждённого официального зеркала того же Linux-архива обнаружить не удалось. Целостность загрузки контролируется SHA-256:

```text
8a804fe78a3950a6ca137e91dfac2de0f952589b0b6674ba903204c6a7a0f495
```

Драйвер использует PCL6 и не требует наличия дополнительного комплекта PostScript 3/MX-PK13.