### PR TITLE
epm play: add amethyst-mod-manager

### DIFF
--- a/play.d/amethyst-mod-manager.sh
+++ b/play.d/amethyst-mod-manager.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+PKGNAME=amethyst-mod-manager
+SUPPORTEDARCHES="x86_64"
+VERSION="$2"
+DESCRIPTION="Amethyst Mod Manager - a Linux native mod manager for a variety of games"
+URL="https://github.com/ChrisDKN/Amethyst-Mod-Manager"
+
+. $(dirname $0)/common.sh
+
+epm assure dwarfsextract dwarfs-tools || fatal
+
+if [ "$VERSION" = "*" ] ; then
+    PKGURL=$(get_github_url "$URL" "AmethystModManager-$VERSION-x86_64.AppImage")
+else
+    PKGURL="$URL/releases/download/v$VERSION/AmethystModManager-$VERSION-x86_64.AppImage"
+fi
+
+install_pkgurl

--- a/repack.d/AmethystModManager.sh
+++ b/repack.d/AmethystModManager.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -x
+
+BUILDROOT="$1"
+SPEC="$2"
+
+PKGNAME=amethyst-mod-manager
+
+. $(dirname $0)/common.sh
+
+stop_libs_requires
+subst "s|^Name:.*|Name: $PKGNAME|" $SPEC


### PR DESCRIPTION
Добавлена зависимость на `dwarfs-tools`: актуальный upstream AppImage использует DwarFS.

Зависимость: перед слиянием нужен [ERC PR #9](https://github.com/Etersoft/erc/pull/9) с поддержкой безопасного извлечения DwarFS AppImage.